### PR TITLE
publish package to npm when a new release is published

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,16 +1,9 @@
 name: publish
 
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - LICENSE
-            - README.md
-            - tsconfig.json
-            - package.json
-            - package-lock.json
-            - src/**/*.ts
+    release:
+        types:
+            - published
 
 jobs:
     publish:


### PR DESCRIPTION
auto publishing on every commit is not necessary at the moment.