### PR TITLE
merge secret entry with different revisions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@castellum/vault",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@castellum/vault",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@stryker-mutator/core": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@castellum/vault",
 	"private": false,
 	"license": "MIT",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"type": "commonjs",
 	"main": "dist/Vault.js",
 	"types": "./dist/Vault.d.ts",

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -15,12 +15,22 @@ export class Vault {
 		return [...this._secrets]
 	}
 
+	public getByName(name: string): SecretEntry {
+		const secret = this._secrets.find((s) => s.name === name)
+
+		if (secret === undefined) {
+			throw new Error(`No entry found with name "${name}"`)
+		}
+
+		return secret
+	}
+
 	public put(secret: SecretEntry): Vault {
 		const existingSecret = this._secrets.find((s: SecretEntry): boolean => s.name === secret.name)
 
 		return existingSecret === undefined
 			? new Vault(this.id, this.owner, this.name, [...this._secrets, secret])
-			: this.overwrite(secret, existingSecret)
+			: this.updateEntry(secret, existingSecret)
 	}
 
 	public archive(name: string, archivedAt: number, author: Author): Vault {
@@ -31,8 +41,8 @@ export class Vault {
 		return new Vault(this.id, this.owner, this.name, entries)
 	}
 
-	private overwrite(newEntry: SecretEntry, existingEntry: SecretEntry): Vault {
-		const updatedSecret = existingEntry.update(newEntry.value, newEntry.createdAt, newEntry.author)
+	private updateEntry(newEntry: SecretEntry, existingEntry: SecretEntry): Vault {
+		const updatedSecret = existingEntry.merge(newEntry)
 
 		const secrets = this._secrets.map(
 			(s: SecretEntry): SecretEntry => (s.name === newEntry.name ? updatedSecret : s),

--- a/src/Vault/Repository/InMemoryRepository.test.ts
+++ b/src/Vault/Repository/InMemoryRepository.test.ts
@@ -26,7 +26,7 @@ describe("InMemoryRepository", () => {
 		const repository = new InMemoryRepository([])
 		let vault = await repository.create(new Author("user-1"), new VaultName("my-vault"))
 
-		const secret = SecretEntry.create(new Author("user-1"), 1677910538, "my-secret-entry", initialValue)
+		const secret = SecretEntry.create("my-secret-entry", new Author("user-1"), 1677910538, initialValue)
 		vault = vault.put(secret)
 
 		await repository.update(vault)
@@ -41,7 +41,7 @@ describe("InMemoryRepository", () => {
 		const professionalVault = await repository.create(new Author("user-1"), new VaultName("pro-vault"))
 
 		let personalVault = await repository.create(new Author("user-1"), new VaultName("my-vault"))
-		const secret = SecretEntry.create(new Author("user-1"), 1677910538, "my-secret-entry", initialValue)
+		const secret = SecretEntry.create("my-secret-entry", new Author("user-1"), 1677910538, initialValue)
 		personalVault = personalVault.put(secret)
 
 		await repository.update(personalVault)

--- a/src/Vault/SecretEntry.test.ts
+++ b/src/Vault/SecretEntry.test.ts
@@ -1,7 +1,6 @@
 import assert from "assert"
 import "mocha"
 import { SecretEntry } from "./SecretEntry"
-import { Revision } from "./SecretEntry/Revision"
 import { Author } from "../Author"
 import { WebLoginSecret } from "./SecretEntry/SecretValue/WebLoginSecret"
 import { NoteSecret } from "./SecretEntry/SecretValue/NoteSecret"
@@ -12,65 +11,93 @@ describe("SecretEntry", (): void => {
 	const initialAuthor = new Author("user-1")
 	const anotherAuthor = new Author("user-2")
 	const initialWebLoginValue = new WebLoginSecret("initial url", "initial username", "initial value", "initial notes")
-	const initialWebLoginEntry = new SecretEntry(initialAuthor, name, createdAt, initialWebLoginValue, [], null)
+	const initialWebLoginEntry = SecretEntry.create(name, initialAuthor, createdAt, initialWebLoginValue)
 	const updatedWebLoginValue = new WebLoginSecret("updated url", "updated username", "updated value", "updated notes")
 
 	it("web login must be created with given values", () => {
 		assert.equal(initialWebLoginEntry.name, name)
-		assert.equal(initialWebLoginEntry.author, initialAuthor)
-		assert.equal(initialWebLoginEntry.createdAt, createdAt)
-		assert.equal(initialWebLoginEntry.value, initialWebLoginValue)
-		assert.equal(initialWebLoginEntry.value.typeName(), "castellum.web-login")
-		assert.equal(initialWebLoginEntry.archivedAt, null)
+		assert.equal(initialWebLoginEntry.current().author, initialAuthor)
+		assert.equal(initialWebLoginEntry.current().createdAt, createdAt)
+		assert.equal(initialWebLoginEntry.current().value, initialWebLoginValue)
+		assert.equal(initialWebLoginEntry.current().value.typeName(), "castellum.web-login")
+		assert.equal(initialWebLoginEntry.current().archived, false)
+		assert.equal(initialWebLoginEntry.revisions().length, 1)
 	})
+
 	it("secret note must be created with given values", () => {
 		const initialNoteValue = new NoteSecret("my secret note")
-		const initialEntry = new SecretEntry(initialAuthor, name, createdAt, initialNoteValue, [], null)
+		const initialEntry = SecretEntry.create(name, initialAuthor, createdAt, initialNoteValue)
 
 		assert.equal(initialEntry.name, name)
-		assert.equal(initialEntry.author, initialAuthor)
-		assert.equal(initialEntry.createdAt, createdAt)
-		assert.equal(initialEntry.value, initialNoteValue)
-		assert.equal(initialEntry.value.typeName(), "castellum.note")
-		assert.equal(initialEntry.archivedAt, null)
+		assert.equal(initialEntry.current().author, initialAuthor)
+		assert.equal(initialEntry.current().createdAt, createdAt)
+		assert.equal(initialEntry.current().value, initialNoteValue)
+		assert.equal(initialEntry.current().value.typeName(), "castellum.note")
+		assert.equal(initialEntry.current().archived, false)
+		assert.equal(initialEntry.revisions().length, 1)
 	})
 
 	it("it must be updated with given value and add a revision with previous value", (): void => {
 		const updatedAt = 1677630902
+		const initialRevision = initialWebLoginEntry.current()
 		const updated = initialWebLoginEntry.update(updatedWebLoginValue, updatedAt, anotherAuthor)
 
 		assert.equal(updated.name, name)
-		assert.equal(updated.author, anotherAuthor)
-		assert.equal(updated.createdAt, updatedAt)
-		assert.equal(updated.value, updatedWebLoginValue)
-		assert.equal(updated.archivedAt, null)
+		assert.equal(updated.current().author, anotherAuthor)
+		assert.equal(updated.current().createdAt, updatedAt)
+		assert.equal(updated.current().value, updatedWebLoginValue)
+		assert.equal(updated.current().archived, false)
+		assert.deepStrictEqual(updated.revisions(), [initialRevision, updated.current()])
+	})
 
-		assert.deepStrictEqual(updated.revisions(), [new Revision(createdAt, initialWebLoginValue, initialAuthor)])
+	it("it must merge with different revisions", (): void => {
+		const updatedAt = 1677630902
+		const initialRevision = initialWebLoginEntry.current()
+		const updated = initialWebLoginEntry.update(updatedWebLoginValue, updatedAt, anotherAuthor)
+		assert.deepStrictEqual(updated.revisions(), [initialRevision, updated.current()])
 
-		const revision = updated.revisions()[0]
+		const anotherUpdatedWebLoginValue = new WebLoginSecret(
+			"another updated url",
+			"another updated username",
+			"another updated value",
+			"other updated notes",
+		)
+		const yetAnotherAuthor = new Author("user-3")
+		const anotherUpdatedAt = 1677630903
+		const anotherUpdated = initialWebLoginEntry.update(
+			anotherUpdatedWebLoginValue,
+			anotherUpdatedAt,
+			yetAnotherAuthor,
+		)
 
-		if (revision === undefined) {
-			assert.fail("Failed to get revision")
-		} else {
-			assert.equal(revision.createdAt, createdAt)
-			assert.equal(revision.value, initialWebLoginValue)
-			assert.deepStrictEqual(revision.author, initialAuthor)
-		}
+		const merged = updated.merge(anotherUpdated)
+		assert.deepStrictEqual(merged.current(), anotherUpdated.current())
+
+		assert.equal(merged.name, name)
+		assert.equal(merged.current().author, yetAnotherAuthor)
+		assert.equal(merged.current().createdAt, anotherUpdatedAt)
+		assert.equal(merged.current().value, anotherUpdatedWebLoginValue)
+		assert.equal(merged.current().archived, false)
+		assert.deepStrictEqual(merged.revisions(), [initialRevision, updated.current(), anotherUpdated.current()])
 	})
 
 	it("it must be archived at given timestamp", (): void => {
+		const initialRevision = initialWebLoginEntry.current()
+
 		const archivedAt = 1677630902
 		const archived = initialWebLoginEntry.archive(archivedAt, anotherAuthor)
 
 		assert.equal(archived.name, name)
-		assert.equal(archived.author, anotherAuthor)
-		assert.equal(archived.createdAt, createdAt)
-		assert.equal(archived.value, initialWebLoginValue)
-		assert.equal(archived.archivedAt, archivedAt)
-		assert.deepStrictEqual(archived.revisions(), [])
+		assert.equal(archived.current().author, anotherAuthor)
+		assert.equal(archived.current().createdAt, archivedAt)
+		assert.equal(archived.current().value, initialWebLoginValue)
+		assert.equal(archived.current().archived, true)
+		assert.deepStrictEqual(archived.revisions(), [initialRevision, archived.current()])
 	})
 
 	it("it must be archived with a revision", (): void => {
+		const initialRevision = initialWebLoginEntry.current()
+
 		const updatedAt = 1677630902
 		const updated = initialWebLoginEntry.update(updatedWebLoginValue, updatedAt, anotherAuthor)
 
@@ -79,12 +106,10 @@ describe("SecretEntry", (): void => {
 		const archived = updated.archive(archivedAt, archivedBy)
 
 		assert.equal(archived.name, name)
-		assert.equal(archived.author, archivedBy)
-		assert.equal(archived.createdAt, updatedAt)
-		assert.equal(archived.value, updatedWebLoginValue)
-		assert.equal(archived.archivedAt, archivedAt)
-		assert.deepStrictEqual(archived.revisions(), [
-			new Revision(initialWebLoginEntry.createdAt, initialWebLoginEntry.value, initialAuthor),
-		])
+		assert.equal(archived.current().author, archivedBy)
+		assert.equal(archived.current().createdAt, archivedAt)
+		assert.equal(archived.current().value, updatedWebLoginValue)
+		assert.equal(archived.current().archived, true)
+		assert.deepStrictEqual(archived.revisions(), [initialRevision, updated.current(), archived.current()])
 	})
 })

--- a/src/Vault/SecretEntry/Revision.ts
+++ b/src/Vault/SecretEntry/Revision.ts
@@ -1,6 +1,21 @@
 import type { Author } from "../../Author"
 import type { SecretValue } from "./SecretValue"
+import { webcrypto } from "crypto"
 
 export class Revision {
-	constructor(readonly createdAt: number, readonly value: SecretValue, readonly author: Author) {}
+	constructor(
+		readonly id: string,
+		readonly createdAt: number,
+		readonly value: SecretValue,
+		readonly author: Author,
+		readonly archived: boolean,
+	) {}
+
+	public static create(createdAt: number, value: SecretValue, author: Author): Revision {
+		return new Revision(webcrypto.randomUUID(), createdAt, value, author, false)
+	}
+
+	public archive(archivedBy: Author, archivedAt: number): Revision {
+		return new Revision(webcrypto.randomUUID(), archivedAt, this.value, archivedBy, true)
+	}
 }


### PR DESCRIPTION
it's possible a revision will be updated concurrently, by different people, or through different interfaces, in such cases all revisions should be stored,
and the last one to be applied should become the
current one.