### PR TITLE
make secret entry constructor public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@castellum/vault",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@castellum/vault",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@stryker-mutator/core": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@castellum/vault",
 	"private": false,
 	"license": "MIT",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"type": "commonjs",
 	"main": "dist/Vault.js",
 	"types": "./dist/Vault.d.ts",

--- a/src/Vault/SecretEntry.ts
+++ b/src/Vault/SecretEntry.ts
@@ -3,7 +3,7 @@ import type { Author } from "../Author"
 import type { SecretValue } from "./SecretEntry/SecretValue"
 
 export class SecretEntry {
-	private constructor(readonly name: string, readonly revision: string, private readonly _revisions: Revision[]) {}
+	public constructor(readonly name: string, readonly revision: string, private readonly _revisions: Revision[]) {}
 
 	public static create(name: string, author: Author, createdAt: number, value: SecretValue): SecretEntry {
 		const revision = Revision.create(createdAt, value, author)


### PR DESCRIPTION
in order to rebuild a secret entry from storage,
the constructor must be public to keep UUID values unchanged.